### PR TITLE
Faster pipeline execution

### DIFF
--- a/Shuttle.Core.Pipelines/PipelineStage.cs
+++ b/Shuttle.Core.Pipelines/PipelineStage.cs
@@ -12,11 +12,12 @@ namespace Shuttle.Core.Pipelines
         public PipelineStage(string name)
         {
             Name = name;
+            Events = new ReadOnlyCollection<IPipelineEvent>(PipelineEvents);
         }
 
         public string Name { get; }
 
-        public IEnumerable<IPipelineEvent> Events => new ReadOnlyCollection<IPipelineEvent>(PipelineEvents);
+        public IEnumerable<IPipelineEvent> Events { get; }
 
         public IPipelineStage WithEvent<TPipelineEvent>() where TPipelineEvent : IPipelineEvent, new()
         {

--- a/Shuttle.Core.Pipelines/Shuttle.Core.Pipelines.csproj
+++ b/Shuttle.Core.Pipelines/Shuttle.Core.Pipelines.csproj
@@ -14,8 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shuttle.Core.Container" Version="11.2.1" />
+    <PackageReference Include="Shuttle.Core.Container" Version="11.2.3" />
     <PackageReference Include="Shuttle.Core.Contract" Version="10.0.3" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
MethodInfo.Invoke has multiple problems: It is slow and allocates unnecessary object array.

With the following test code I compared the memory allocation and speed of the invokes before and after the change (*):
```
    public class MockPipelineEvent1 : PipelineEvent {}
    public class MockPipelineEvent2 : PipelineEvent {}
    public class MockPipelineEvent3 : PipelineEvent {}

    public class MockAuthenticateObserver :
        IPipelineObserver<MockPipelineEvent1>,
        IPipelineObserver<MockPipelineEvent2>,
        IPipelineObserver<MockPipelineEvent3>
    {
        public string CallSequence { get; private set; } = string.Empty;

        public void Execute(MockPipelineEvent1 pipelineEvent) {}
        public void Execute(MockPipelineEvent2 pipelineEvent) {}
        public void Execute(MockPipelineEvent3 pipelineEvent) {}
    }

    class Program
    {
        static void Main(string[] args)
        {
            var pipeline = new Pipeline();

            pipeline
                .RegisterStage("Stage")
                .WithEvent<MockPipelineEvent1>()
                .WithEvent<MockPipelineEvent2>()
                .WithEvent<MockPipelineEvent3>();

            var observer = new MockAuthenticateObserver();

            pipeline.RegisterObserver(observer);
            pipeline.Execute();

            var sw = Stopwatch.StartNew();
            for (int i = 0; i < 1000000; i++)
            {
                pipeline.Execute();
            }

            var x = sw.ElapsedMilliseconds;
            Console.WriteLine(x);
            Console.ReadLine();
        }
    }

```

Results:
Before the change:
![image](https://user-images.githubusercontent.com/3104253/107269140-6f749400-6a49-11eb-97b8-f02e758b020b.png)

![image](https://user-images.githubusercontent.com/3104253/107270483-494ff380-6a4b-11eb-9727-0a93c7939584.png)

After the change:
![image](https://user-images.githubusercontent.com/3104253/107269259-a21e8c80-6a49-11eb-97e4-56fa144caf68.png)

![image](https://user-images.githubusercontent.com/3104253/107270367-26bdda80-6a4b-11eb-9f92-cdacf15f00c0.png)

List Enumerator is just a struct, so it does not matter.

(*) Except the change in the PipelineStage class, which is just a "cache" for the read only collection.

The new ObserverMethodInvoker dynamically compiles a method which, which will run much faster. The measure above of course has a quite big overhead, but without measure it is still more than 2 times faster and uses much less memory allocation, which means less GC overhead. 